### PR TITLE
FMAIL-26744: fix fallback to border

### DIFF
--- a/src/shorthands.ts
+++ b/src/shorthands.ts
@@ -123,3 +123,12 @@ for (const shorthand of shorthandKeys) {
 		shorthandReverseMap[fullProp].push(shorthand);
 	}
 }
+
+// Adding border fallback for each full property
+for (const side of sides) {
+    for (const prop of borderCommonProps) {
+        const fullBorderProp = `border-${side}-${prop}`;
+        shorthandReverseMap[fullBorderProp] = shorthandReverseMap[fullBorderProp] ?? [];
+        shorthandReverseMap[fullBorderProp].push("border");
+    }
+}

--- a/tests/__snapshots__/index.tests.ts.snap
+++ b/tests/__snapshots__/index.tests.ts.snap
@@ -62,6 +62,7 @@ Object {
   "border-bottom-color": Array [
     "border-color",
     "border-bottom",
+    "border",
   ],
   "border-bottom-left-radius": Array [
     "border-radius",
@@ -72,10 +73,12 @@ Object {
   "border-bottom-style": Array [
     "border-style",
     "border-bottom",
+    "border",
   ],
   "border-bottom-width": Array [
     "border-width",
     "border-bottom",
+    "border",
   ],
   "border-color": Array [
     "border",
@@ -83,26 +86,32 @@ Object {
   "border-left-color": Array [
     "border-color",
     "border-left",
+    "border",
   ],
   "border-left-style": Array [
     "border-style",
     "border-left",
+    "border",
   ],
   "border-left-width": Array [
     "border-width",
     "border-left",
+    "border",
   ],
   "border-right-color": Array [
     "border-color",
     "border-right",
+    "border",
   ],
   "border-right-style": Array [
     "border-style",
     "border-right",
+    "border",
   ],
   "border-right-width": Array [
     "border-width",
     "border-right",
+    "border",
   ],
   "border-style": Array [
     "border",
@@ -110,6 +119,7 @@ Object {
   "border-top-color": Array [
     "border-color",
     "border-top",
+    "border",
   ],
   "border-top-left-radius": Array [
     "border-radius",
@@ -120,10 +130,12 @@ Object {
   "border-top-style": Array [
     "border-style",
     "border-top",
+    "border",
   ],
   "border-top-width": Array [
     "border-width",
     "border-top",
+    "border",
   ],
   "border-width": Array [
     "border",

--- a/tests/index.tests.ts
+++ b/tests/index.tests.ts
@@ -11,6 +11,7 @@ describe("lookupShorthands", () => {
 		expect(lookupShorthands("border-top-color")).toEqual([
 			"border-color",
 			"border-top",
+			"border",
 		]);
 	});
 


### PR DESCRIPTION
**Проблема**

В случае, если граница задана свойством border и содержит в себе переменную (`border: 1px solid var(--vkui--color_field_border_alpha);`) функция lookupShorthands возвращает пустой массив.

Из-за этого при использовании этого свойства оно просто "съедается" и исчезает совсем.

**Причина проблемы**

В текущей реализации для каждого значения map присутствуют только фоллбеки на сами свойства - к примеру, для `'border-left-color'` это `'border-color'` и `'border-left'`.

При этом цвет для границы слева может быть определен самим свойством border - и в данном случае это значение будет потеряно.

**Решение**

Добавить для каждого полного ключа из семейства border фоллбек на чистый border.

Это сделано после создания обратной map, потому что иначе можно получить неправильную зависимость с другой стороной (border-left-color, которая зависит от border-top).

<details><summary>Тесты</summary>
<p>

![изображение](https://github.com/user-attachments/assets/1416a18a-0d94-4226-a05f-1276a2f03507)


</p>
</details> 